### PR TITLE
test: Isolate and update course test suite

### DIFF
--- a/server/tests/crud/test_course_crud.py
+++ b/server/tests/crud/test_course_crud.py
@@ -1,66 +1,134 @@
-import os
-import pickle
 import uuid
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
 
-from app.crud import CRUDCourse
-from app.schemas import Course
-
-
-@pytest.fixture
-def mock_path(tmp_path):
-    return str(tmp_path / "test_courses.pkl")
+from app.crud.course_crud import course_crud
+from mock_models import TestBase, MockCourse, MockEvaluation, MockLecture, MockUser, \
+    MockCourseSchema, MockEvaluationSchema, MockLectureSchema
 
 
-@pytest.fixture
-def crud_course(mock_path):
-    return CRUDCourse(courses_file_path=mock_path)
+@pytest.fixture(scope="function")
+def test_db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        TestBase.metadata.drop_all(bind=engine)
 
 
-@pytest.fixture
-def sample_course():
-    return Course(
+@pytest.fixture(scope="function")
+def mock_models(monkeypatch):
+    monkeypatch.setattr(course_crud, 'model', MockCourse)
+    monkeypatch.setattr('app.models.Evaluation', MockEvaluation)
+    monkeypatch.setattr('app.models.Lecture', MockLecture)
+
+
+@pytest.fixture(scope="function")
+def test_user(test_db_session: Session) -> MockUser:
+    user = MockUser(uuid=str(uuid.uuid4()))
+    test_db_session.add(user)
+    test_db_session.commit()
+    test_db_session.refresh(user)
+    return user
+
+
+def test_get_course(test_db_session: Session, test_user: MockUser, mock_models):
+    course_in = MockCourseSchema(uuid=str(uuid.uuid4()), title="Calculus I")
+    course_crud.create_with_children(db=test_db_session, obj_in=course_in, owner_uuid=test_user.uuid)
+
+    retrieved_course = course_crud.get(db=test_db_session, obj_uuid=course_in.uuid)
+
+    assert retrieved_course is not None
+    assert retrieved_course.uuid == course_in.uuid
+
+
+def test_get_multi_courses(test_db_session: Session, test_user: MockUser):
+    for i in range(5):
+        course_in = MockCourseSchema(uuid=str(uuid.uuid4()), title=f"Course {i}")
+        course_crud.create_with_children(
+            db=test_db_session, obj_in=course_in, owner_uuid=test_user.uuid
+        )
+
+    first_two = course_crud.get_multi(test_db_session, limit=2)
+    assert len(first_two) == 2
+
+    next_two = course_crud.get_multi(test_db_session, skip=2, limit=2)
+    assert len(next_two) == 2
+
+    assert first_two[0].title == "Course 0"
+    assert next_two[0].title == "Course 2"
+
+
+def test_get_all_by_owner_uuid(test_db_session: Session, test_user: MockUser, mock_models):
+    course_in_1 = MockCourseSchema(uuid=str(uuid.uuid4()), title="Algorithms")
+    course_crud.create_with_children(db=test_db_session, obj_in=course_in_1, owner_uuid=test_user.uuid)
+
+    courses = course_crud.get_all_by_owner_uuid(db=test_db_session, owner_uuid=test_user.uuid)
+
+    assert len(courses) == 1
+    assert courses[0].title == "Algorithms"
+
+
+def test_create_with_children(test_db_session: Session, test_user: MockUser, mock_models):
+    course_in = MockCourseSchema(
         uuid=str(uuid.uuid4()),
-        title="DS",
+        title="Self-Contained Systems",
         semester="2025.2",
-        lectures=[],
-        evaluations=[])
+        evaluations=[MockEvaluationSchema(title="Final Project")],
+        lectures=[MockLectureSchema(title="Intro to Microservices")]
+    )
+
+    db_course = course_crud.create_with_children(db=test_db_session, obj_in=course_in, owner_uuid=test_user.uuid)
+
+    assert db_course is not None
+    assert db_course.title == "Self-Contained Systems"
+    assert db_course.owner_uuid == test_user.uuid
+    assert len(db_course.evaluations) == 1
+    assert db_course.evaluations[0].title == "Final Project"
+    assert len(db_course.lectures) == 1
+    assert db_course.lectures[0].title == "Intro to Microservices"
 
 
-def test_initialization_with_no_file(crud_course):
-    assert crud_course.courses == []
+def test_update_course(test_db_session: Session, test_user: MockUser):
+    course_in = MockCourseSchema(uuid=str(uuid.uuid4()), title="Old Title", semester="2025.1")
+    db_course = course_crud.create_with_children(
+        db=test_db_session, obj_in=course_in, owner_uuid=test_user.uuid
+    )
+
+    update_data = {"title": "New Title", "archived": True}
+    updated_course = course_crud.update(
+        db=test_db_session, db_obj=db_course, obj_in=update_data
+    )
+
+    test_db_session.refresh(updated_course)
+    assert updated_course.title == "New Title"
+    assert updated_course.archived is True
+    assert updated_course.semester == "2025.1"  # Assert non-updated field remains the same
 
 
-def test_read_courses_from_file(mock_path, sample_course):
-    mock_course_data = [sample_course]
-    with open(mock_path, "wb") as f:
-        # noinspection PyTypeChecker
-        pickle.dump(mock_course_data, f)
+def test_remove_course_with_cascading_delete(test_db_session: Session, test_user: MockUser):
+    course_in = MockCourseSchema(
+        uuid=str(uuid.uuid4()),
+        title="Course to Delete",
+        semester="2025.2",
+        evaluations=[MockEvaluationSchema(title="Midterm")],
+        lectures=[MockLectureSchema(title="First Class")]
+    )
+    db_course = course_crud.create_with_children(
+        db=test_db_session, obj_in=course_in, owner_uuid=test_user.uuid
+    )
+    assert test_db_session.query(MockEvaluation).count() == 1
+    assert test_db_session.query(MockLecture).count() == 1
 
-    crud = CRUDCourse(courses_file_path=mock_path)
-    assert crud.get_courses() == mock_course_data
+    removed_course = course_crud.remove(test_db_session, obj_uuid=db_course.uuid)
 
-
-def test_write_courses_to_file(crud_course, mock_path, sample_course):
-    crud_course.courses = [sample_course]
-
-    crud_course.write_courses_to_file(file_path=mock_path)
-
-    assert os.path.exists(mock_path)
-    with open(mock_path, "rb") as f:
-        data_from_file = pickle.load(f)
-    assert data_from_file == [sample_course]
-
-
-def test_get_courses(crud_course, sample_course):
-    crud_course.courses = [sample_course]
-    assert crud_course.get_courses() == [sample_course]
-
-
-def test_append_course(crud_course, sample_course):
-    crud_course.append_course(sample_course)
-    assert crud_course.courses == [sample_course]
-
-    crud_course.append_course(sample_course)
-    assert crud_course.courses == [sample_course, sample_course]
+    assert removed_course is not None
+    assert test_db_session.query(MockCourse).count() == 0
+    assert test_db_session.query(MockEvaluation).count() == 0
+    assert test_db_session.query(MockLecture).count() == 0

--- a/server/tests/routers/test_course_router.py
+++ b/server/tests/routers/test_course_router.py
@@ -1,4 +1,3 @@
-import uuid
 from io import BytesIO
 from unittest.mock import MagicMock, AsyncMock
 
@@ -6,71 +5,96 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
-from app.crud import CRUDChat, CRUDCourse, get_chat_crud, get_course_crud
+from app.core.security import get_current_user
+from app.crud import get_course_crud
+from app.dependencies import get_db
 from app.main import app
-from app.schemas import Course, CourseBase
-from app.services import GoogleAIService, get_google_ai_service
+from app.services import get_google_ai_service
+from mock_models import MockCourse, MockUser
 
 
-@pytest.fixture
-def mock_chat_crud():
-    return MagicMock(spec=CRUDChat)
+def override_get_db():
+    pass
 
 
 @pytest.fixture
 def mock_course_crud():
-    crud = MagicMock(spec=CRUDCourse)
-    crud.get_courses.return_value = []
+    crud = MagicMock()
+    crud.get_all_by_owner_uuid.return_value = [
+        MockCourse(uuid="test-uuid-1", title="DS", semester="2025.2")
+    ]
+    crud.create_with_children.return_value = MockCourse(
+        uuid="new-course-uuid", title="New Course", semester="2025.2"
+    )
     return crud
 
 
 @pytest.fixture
 def mock_ai_service():
-    service = MagicMock(spec=GoogleAIService)
-    service.generate_structured_output = AsyncMock(return_value=CourseBase(
-        title="DS",
-        semester="2025.2",
-        lectures=[],
-        evaluations=[]))
+    service = MagicMock()
+
+    from app.routers.course_router import LecturesCreate, EvaluationsCreate
+    from app.schemas import CourseBase
+
+    service.generate_structured_output = AsyncMock(side_effect=[
+        CourseBase(title="New Course", semester="2025.2"),
+        LecturesCreate(lectures=[], has_more=True),
+        LecturesCreate(lectures=[], has_more=False),
+        EvaluationsCreate(evaluations=[], has_more=True),
+        EvaluationsCreate(evaluations=[], has_more=False),
+    ])
     return service
 
 
 @pytest.fixture
-def client(mock_chat_crud, mock_course_crud, mock_ai_service):
-    app.dependency_overrides[get_chat_crud] = lambda: mock_chat_crud
+def mock_current_user():
+    return MockUser(uuid="user-from-token")
+
+
+@pytest.fixture
+def client(mock_course_crud, mock_ai_service, mock_current_user):
+    app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_course_crud] = lambda: mock_course_crud
     app.dependency_overrides[get_google_ai_service] = lambda: mock_ai_service
+    app.dependency_overrides[get_current_user] = lambda: mock_current_user
+
     with TestClient(app) as test_client:
         yield test_client
+
     app.dependency_overrides = {}
 
 
-def test_get_courses(client, mock_course_crud):
-    mock_courses = [Course(uuid=str(uuid.uuid4()), title="DS", semester="2025.2", lectures=[], evaluations=[])]
-    mock_course_crud.get_courses.return_value = mock_courses
-
+def test_list_courses(client, mock_course_crud, mock_current_user):
     response = client.get("/course/list")
 
     assert response.status_code == 200
-    assert response.json() == [course.model_dump() for course in mock_courses]
-    mock_course_crud.get_courses.assert_called_once()
+    assert len(response.json()) == 1
+    assert response.json()[0]["title"] == "DS"
+    mock_course_crud.get_all_by_owner_uuid.assert_called_once_with(
+        db=None, owner_uuid=mock_current_user.uuid
+    )
 
 
 @pytest.mark.asyncio
-async def test_create_course_success(client, mock_course_crud, mock_chat_crud, mock_ai_service):
+async def test_create_course_success(client, mock_course_crud, mock_ai_service, mock_current_user):
     file_content = b"pdf content"
     files = [("files", ("mock.pdf", BytesIO(file_content), "application/pdf"))]
     message = "Mock message."
 
     response = client.post("/course/create", files=files, data={"message": message})
 
-    assert response.status_code == 201
-    mock_ai_service.generate_structured_output.assert_awaited_once()
-    mock_course_crud.append_course.assert_called_once()
-    assert mock_chat_crud.append_llm_context.call_count == 2
+    assert response.status_code == 201, f"Response text: {response.text}"
+    assert response.json()["title"] == "New Course"
+
+    mock_course_crud.create_with_children.assert_called_once()
+    call_args = mock_course_crud.create_with_children.call_args[1]
+    assert call_args['owner_uuid'] == mock_current_user.uuid
+
+    assert mock_ai_service.generate_structured_output.await_count == 5
 
 
-def test_create_course_unsupported_media_type(client):
+@pytest.mark.asyncio
+async def test_create_course_unsupported_media_type(client):
     file_content = b"zip content"
     files = [("files", ("mock.zip", BytesIO(file_content), "application/zip"))]
 
@@ -80,7 +104,8 @@ def test_create_course_unsupported_media_type(client):
     assert "Unsupported Media Type" in response.json()["detail"]
 
 
-def test_create_course_entity_too_large(client):
+@pytest.mark.asyncio
+async def test_create_course_entity_too_large(client):
     large_content = b"0" * (20 * 1024 * 1024)
     files = [("files", ("large_file.pdf", BytesIO(large_content), "application/pdf"))]
 


### PR DESCRIPTION
This PR overhauls the tests for `course_crud` and `course_router` to fix critical failures and improve test coverage and isolation.

The previous tests were outdated and tested a file-based implementation. They have been rewritten to support the new database-centric architecture using SQLAlchemy.

- Added tests for the inherited `update`, `remove`, and `get_multi` methods in `test_course_crud.py`.
- Implemented a critical test to verify that cascading deletes on child lectures and evaluations work as expected.
- Modified the `course_router` to properly use FastAPI's `Depends` for the AI service in helper functions. This resolves a major bug where tests were making real network calls.
- Centralized all mock models into a reusable `tests/mock_models.py` file for better organization.