### PR TITLE
refactor: Replace iterative generation with single AI call

### DIFF
--- a/server/app/routers/course_router.py
+++ b/server/app/routers/course_router.py
@@ -2,7 +2,6 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, Form, UploadFile, Depends
 from google.genai.types import Content, Part
-from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from starlette import status
 
@@ -11,8 +10,7 @@ from app.core.security import get_current_user
 from app.crud import get_chat_crud, get_course_crud
 from app.dependencies import get_db
 from app.models import User
-from app.schemas import Course, CourseBase, CourseUpdate, CourseDeleteResponse, Lecture, LectureBase, Evaluation, \
-    EvaluationBase
+from app.schemas import Course, CourseUpdate, CourseGenerate, CourseDeleteResponse, Lecture, Evaluation
 from app.services import get_google_ai_service, GoogleAIService
 
 course_router = APIRouter(
@@ -41,11 +39,27 @@ async def create_course(
         ai_service: GoogleAIService = Depends(get_google_ai_service)):
     validate_files(files)
     try:
-        course: Course = await create_course_iterative(
-            files=[(await file.read(), file.content_type) for file in files], message=message, ai_service=ai_service)
+        course_generated = await ai_service.generate_structured_output(
+            files=[(await file.read(), file.content_type) for file in files],
+            schema=CourseGenerate,
+            message=message,
+        )
     except Exception:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
-    system_message = settings.SYSTEM_MESSAGE_MARKER_START + course.model_dump_json() + settings.SYSTEM_MESSAGE_MARKER_END
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error while parsing course information"
+        )
+
+    system_message = settings.SYSTEM_MESSAGE_MARKER_START + course_generated.model_dump_json() + settings.SYSTEM_MESSAGE_MARKER_END
+    course: Course = Course(
+        uuid=str(uuid.uuid4()),
+        title=course_generated.title,
+        semester=course_generated.semester,
+        lectures=[Lecture(**lecture.model_dump(), uuid=str(uuid.uuid4()))
+                  for lecture in course_generated.lectures],
+        evaluations=[Evaluation(**{**evaluation.model_dump(), "type": evaluation.type.value}, uuid=str(uuid.uuid4()))
+                     for evaluation in course_generated.evaluations]
+    )
     created_course = course_crud.create_with_children(db=db, obj_in=course, owner_uuid=current_user.uuid)
     chat_crud.append_llm_context([Content(role="user", parts=[Part(text=system_message)])])
     chat_crud.append_llm_context([Content(role="model", parts=[Part(text="Certo. Lembrarei disso.")])])
@@ -85,66 +99,3 @@ def validate_files(files: list[UploadFile]) -> None:
         files_size += file.size
         if files_size > 19922944:  # 19MB, leaving 1MB for the rest of the prompt
             raise HTTPException(status_code=413, detail="Request Entity Too Large")
-
-
-class LecturesCreate(BaseModel):
-    lectures: list[LectureBase] = Field(description="The list of lectures parsed from the file in this turn.")
-    has_more: bool = Field(description="Whether there are more lectures to be parsed from the file.")
-
-
-class EvaluationsCreate(BaseModel):
-    evaluations: list[EvaluationBase] = Field(description="The list of evaluations parsed from the file in this turn.")
-    has_more: bool = Field(description="Whether there are more evaluations to be parsed from the file.")
-
-
-async def create_course_iterative(files: list[tuple[bytes, str]],
-                                  message: str | None = None,
-                                  ai_service: GoogleAIService = Depends(get_google_ai_service)) -> Course:
-    course_base: CourseBase = await ai_service.generate_structured_output(
-        instruction="Fill all fields in Brazillian Portuguese.",
-        schema=CourseBase,
-        files=files,
-        message=message)
-    course: Course = Course(uuid=str(uuid.uuid4()), **course_base.model_dump())
-
-    lectures_appended: int = 0
-    while True:
-        instruction_initial: str = (
-            "Parse up to the first ten lectures from the file. Don't confuse lectures with evaluations. Fill all "
-            "properties in Brazillian Portuguese if they don't have a format attribute.")
-        instruction_iteration: str = (
-            f"You have already parsed the first {lectures_appended} lectures from the file, up to "
-            f"{course.lectures[-1].start_datetime if course.lectures else None}. Don't confuse lectures with "
-            f"evaluations. Parse the next up to ten lectures. Fill all properties in Brazillian Portuguese if they "
-            f"don't have a format attribute.")
-        lectures: LecturesCreate = await ai_service.generate_structured_output(
-            instruction=instruction_iteration if lectures_appended > 0 else instruction_initial,
-            schema=LecturesCreate,
-            files=files,
-            message=message)
-        for lecture in lectures.lectures:
-            course.lectures.append(Lecture(uuid=str(uuid.uuid4()), **lecture.model_dump()))
-            lectures_appended += 1
-        if not lectures.has_more:
-            break
-
-    evaluations_appended: int = 0
-    while True:
-        instruction_initial: str = (
-            "Parse up to the first ten evaluations from the file. Don't confuse lectures with evaluations. Fill all "
-            "properties in Brazillian Portuguese if they don't have a format attribute.")
-        instruction_iteration: str = (
-            f"You have already parsed the first {evaluations_appended} evaluations from the file, up to "
-            f"{course.evaluations[-1].start_datetime if course.evaluations else None}. Don't confuse lectures with "
-            f"evaluations. Fill all properties in Brazillian Portuguese if they don't have a format attribute.")
-        evaluations: EvaluationsCreate = await ai_service.generate_structured_output(
-            instruction=instruction_iteration if evaluations_appended > 0 else instruction_initial,
-            schema=EvaluationsCreate,
-            files=files,
-            message=message)
-        for evaluation in evaluations.evaluations:
-            course.evaluations.append(Evaluation(uuid=str(uuid.uuid4()), **evaluation.model_dump()))
-            evaluations_appended += 1
-        if not evaluations.has_more:
-            break
-    return course

--- a/server/app/schemas/__init__.py
+++ b/server/app/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .chat_schemas import ChatRole, ChatMessage
-from .course_schema import Course, CourseBase, CoursesList, CourseCreate, CourseUpdate, CourseSummary, \
+from .course_schema import Course, CourseBase, CourseCreate, CourseUpdate, CourseGenerate, CourseSummary, \
     CourseDeleteResponse
 from .evaluation_schema import EvaluationTypes, Evaluation, EvaluationBase, EvaluationCreate, EvaluationUpdate
 from .event_schema import Event, EventBase, EventCreate, EventCreateInDB, EventUpdate, EventsByDay

--- a/server/app/schemas/course_schema.py
+++ b/server/app/schemas/course_schema.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, ConfigDict, Field
 
-from .evaluation_schema import Evaluation
-from .lecture_schema import Lecture
+from .evaluation_schema import Evaluation, EvaluationBase
+from .lecture_schema import Lecture, LectureBase
 
 
 class CourseBase(BaseModel):
@@ -10,9 +10,6 @@ class CourseBase(BaseModel):
     semester: str | None = Field(
         default=None,
         description="The semester in which the course is offered, like 'Fall 2025', '2025.2' or '2025/2'.")
-    archived: bool = Field(
-        default=False,
-        description="Used by the application for internal control. Preserve default value.")
 
 
 class CourseCreate(CourseBase):
@@ -25,19 +22,22 @@ class CourseUpdate(BaseModel):
     archived: bool | None = None
 
 
+class CourseGenerate(CourseBase):
+    lectures: list[LectureBase] = []
+    evaluations: list[EvaluationBase] = []
+
+
 class Course(CourseBase):
     uuid: str
+    archived: bool = False
     lectures: list[Lecture] = []
     evaluations: list[Evaluation] = []
     model_config = ConfigDict(from_attributes=True)
 
 
-class CoursesList(BaseModel):
-    courses: list[Course]
-
-
 class CourseSummary(CourseBase):
     uuid: str
+    archived: bool = False
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/server/app/schemas/evaluation_schema.py
+++ b/server/app/schemas/evaluation_schema.py
@@ -20,9 +20,6 @@ class EvaluationBase(BaseModel):
         description="The start date and time for the evaluation in ISO 8601 format.")
     end_datetime: str = Field(
         description="The end date and time for the evaluation in ISO 8601 format, which is typically the deadline.")
-    present: bool | None = Field(
-        default=None,
-        description="Used by the application for internal control. Preserve default value.")
 
 
 class EvaluationCreate(EvaluationBase):
@@ -39,4 +36,5 @@ class EvaluationUpdate(BaseModel):
 
 class Evaluation(EvaluationBase):
     uuid: str
+    present: bool | None = None
     model_config = ConfigDict(from_attributes=True)

--- a/server/app/schemas/lecture_schema.py
+++ b/server/app/schemas/lecture_schema.py
@@ -11,9 +11,6 @@ class LectureBase(BaseModel):
     summary: str | None = Field(
         default=None,
         description="A brief summary of the lecture's content.")
-    present: bool | None = Field(
-        default=None,
-        description="Used by the application for internal control. Preserve default value.")
 
 
 class LectureCreate(LectureBase):
@@ -30,4 +27,5 @@ class LectureUpdate(BaseModel):
 
 class Lecture(LectureBase):
     uuid: str
+    present: bool | None = None
     model_config = ConfigDict(from_attributes=True)

--- a/server/tests/mock_models.py
+++ b/server/tests/mock_models.py
@@ -12,11 +12,24 @@ class MockEvaluationTypes(Enum):
     ASSIGNMENT = "assignment"
 
 
+class MockLectureCreate(BaseModel):
+    title: str = "AI Generated Lecture"
+    start_datetime: str = "2025-08-01T10:00:00"
+    end_datetime: str = "2025-08-01T12:00:00"
+
+
 class MockLectureSchema(BaseModel):
     uuid: str = Field(default_factory=lambda: str(uuid.uuid4()))
     title: str = "Test Lecture"
     start_datetime: str = "2025-07-23T14:00:00Z"
     end_datetime: str = "2025-07-23T15:00:00Z"
+
+
+class MockEvaluationCreate(BaseModel):
+    title: str = "AI Generated Evaluation"
+    type: MockEvaluationTypes = MockEvaluationTypes.ASSIGNMENT
+    start_datetime: str = "2025-08-01T12:00:00"
+    end_datetime: str = "2025-08-08T23:59:59"
 
 
 class MockEvaluationSchema(BaseModel):
@@ -25,6 +38,13 @@ class MockEvaluationSchema(BaseModel):
     title: str = "Test Evaluation"
     start_datetime: str = "2025-07-23T09:00:00Z"
     end_datetime: str = "2025-07-28T23:59:59Z"
+
+
+class MockCourseGenerate(BaseModel):
+    title: str = "New Course"
+    semester: str = "2025.2"
+    lectures: list[MockLectureCreate] = [MockLectureCreate()]
+    evaluations: list[MockEvaluationCreate] = [MockEvaluationCreate()]
 
 
 class MockCourseSchema(BaseModel):


### PR DESCRIPTION
The course creation process has been refactored to use a single, comprehensive call to the AI service. This change is driven by an upgrade to a newer LLM (`gemini-2.5-flash-lite`) which supports a much larger output token limit, making the previous iterative parsing approach unnecessary.

This refactor simplifies the logic, improves performance by reducing the number of AI calls, and enhances functionality.

Key changes include:

- Single AI Call: The `create_course_iterative` function has been removed. The create_course endpoint now makes a single call to `ai_service.generate_structured_output` to parse the entire course syllabus, including lectures and evaluations, at once.

- New Pydantic Schema: A `CourseGenerate` schema has been introduced to define the expected structure of the single AI response, replacing the previous `LecturesCreate` and `EvaluationsCreate` schemas.

- Improved Error Handling: The error message for parsing failures is now more descriptive ("Error while parsing course information").

- Schema Cleanup: Pydantic schemas for `Course`, `Lecture`, and `Evaluation` were updated to better separate fields for AI generation from fields used for internal application control (e.g., `present`, `archived`).

- Test Overhaul: Unit tests for the course router have been completely updated to align with the new, non-iterative logic. The AI service mock now returns a single, complete

- `MockCourseGenerate` object, and new tests for timezone validation and updated error messages have been added.