### PR TITLE
feat: Convert course datetimes to UTC on creation

### DIFF
--- a/server/app/utils/time.py
+++ b/server/app/utils/time.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def to_utc_iso(dt_str: str, client_tz: ZoneInfo) -> str:
+    """Converts a naive datetime string to an aware UTC ISO string."""
+    try:
+        dt_naive = datetime.fromisoformat(dt_str)
+        dt_aware = dt_naive.replace(tzinfo=client_tz)
+        dt_utc = dt_aware.astimezone(ZoneInfo("UTC"))
+        return dt_utc.isoformat().replace("+00:00", "Z")
+    except (ValueError, TypeError):
+        return dt_str


### PR DESCRIPTION
This commit introduces timezone awareness to the course creation process. All date and time information for lectures and evaluations generated by the AI is now converted to UTC based on the client's timezone before being saved to the database. This ensures that all timestamps are standardized, preventing ambiguity.

Key changes include:

- The `/course/create` endpoint now accepts a timezone form field to specify the client's local timezone.

- A new utility function, `to_utc_iso`, has been created to handle the conversion of naive datetime strings to the UTC ISO 8601 format.

- This function is applied to the `start_datetime` and `end_datetime` for all generated lectures and evaluations.

- Added validation to handle invalid timezone identifiers, returning a 400 Bad Request error.

- Updated existing tests and added new tests to cover successful timezone conversion and the new error-handling case.