### PR TITLE
test: Update chat endpoint path and resolve test import/config issues

### DIFF
--- a/server/tests/crud/test_chat_crud.py
+++ b/server/tests/crud/test_chat_crud.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from app.crud.chat_crud import chat_crud
-from mock_models import TestBase, MockUser, MockChatMessage, MockChatMessageSchema, MockChatRole
+from tests.mock_models import TestBase, MockUser, MockChatMessage, MockChatMessageSchema, MockChatRole
 
 
 @pytest.fixture(scope="function")

--- a/server/tests/crud/test_course_crud.py
+++ b/server/tests/crud/test_course_crud.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from app.crud.course_crud import course_crud
-from mock_models import TestBase, MockCourse, MockEvaluation, MockLecture, MockUser, \
+from tests.mock_models import TestBase, MockCourse, MockEvaluation, MockLecture, MockUser, \
     MockCourseSchema, MockEvaluationSchema, MockLectureSchema
 
 

--- a/server/tests/mock_models.py
+++ b/server/tests/mock_models.py
@@ -1,11 +1,12 @@
 import uuid
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from sqlalchemy import Column, String, Boolean, ForeignKey, Text, Integer
 from sqlalchemy.orm import declarative_base, relationship
 
 TestBase = declarative_base()
+TestBase.__test__ = False
 
 
 class MockChatRole(Enum):
@@ -76,9 +77,7 @@ class MockCourseSchema(BaseModel):
     archived: bool = False
     lectures: list[MockLectureSchema] = []
     evaluations: list[MockEvaluationSchema] = []
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class MockUser(TestBase):

--- a/server/tests/routers/test_chat_router.py
+++ b/server/tests/routers/test_chat_router.py
@@ -90,7 +90,7 @@ async def test_send_chat_message(client, mock_chat_crud, mock_ai_service, mock_u
         ChatMessage(role=ChatRole.USER, text="Old message", content=json.dumps([history_content.model_dump()]))
     ]
 
-    response = client.post("/chat/send_message", data={"message": user_message_text})
+    response = client.post("/chat/message", data={"message": user_message_text})
 
     assert response.status_code == 200
     assert response.json() == ai_response_text

--- a/server/tests/routers/test_course_router.py
+++ b/server/tests/routers/test_course_router.py
@@ -5,14 +5,14 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from app.core import settings
 from app.core.security import get_current_user
 from app.crud import get_course_crud, get_chat_crud
 from app.dependencies import get_db
 from app.main import app
 from app.schemas import ChatRole
 from app.services import get_google_ai_service
-from core import settings
-from mock_models import MockCourseGenerate, MockCourse, MockUser
+from tests.mock_models import MockCourseGenerate, MockCourse, MockUser
 
 
 def override_get_db():


### PR DESCRIPTION
- Refactored a test to use the correct chat message endpoint path (`/chat/message` instead of `/chat/send_message`).
- Resolved import errors in test files by changing relative paths to absolute paths (e.g., `tests.mock_models` instead of `mock_models`) to ensure consistent test execution from the terminal.
- Addressed Pydantic configuration warnings by updating `Config` to `model_config` and set `TestBase.__test__ = False` to prevent pytest from misinterpreting `TestBase` as a test class.