### PR TITLE
fix: Resolve frontend TypeScript and dependency errors

### DIFF
--- a/planit/babel.config.cjs
+++ b/planit/babel.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     '@babel/preset-env',
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
 };

--- a/planit/package-lock.json
+++ b/planit/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.0",
-        "@mui/icons-material": "^7.1.1",
-        "@mui/material": "^7.1.1",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^5.18.0",
+        "@mui/material": "^5.18.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"
@@ -2126,9 +2126,9 @@
       "license": "MIT"
     },
     "node_modules/@emotion/styled": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
-      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -3362,9 +3362,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.1.1.tgz",
-      "integrity": "sha512-yBckQs4aQ8mqukLnPC6ivIRv6guhaXi8snVl00VtyojBbm+l6VbVhyTSZ68Abcx7Ah8B+GZhrB7BOli+e+9LkQ==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3372,21 +3372,22 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.1.1.tgz",
-      "integrity": "sha512-X37+Yc8QpEnl0sYmz+WcLFy2dWgNRzbswDzLPXG7QU1XDVlP5TPp1HXjdmCupOWLL/I9m1fyhcyZl8/HPpp/Cg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
+      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1"
+        "@babel/runtime": "^7.23.9"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.1.1",
+        "@mui/material": "^5.0.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3397,26 +3398,26 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.1.tgz",
-      "integrity": "sha512-mTpdmdZCaHCGOH3SrYM41+XKvNL0iQfM9KlYgpSjgadXx/fEKhhvOktxm8++Xw6FFeOHoOiV+lzOI8X1rsv71A==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@mui/core-downloads-tracker": "^7.1.1",
-        "@mui/system": "^7.1.1",
-        "@mui/types": "^7.4.3",
-        "@mui/utils": "^7.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
         "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.1.0",
+        "react-is": "^19.0.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3425,7 +3426,6 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3437,26 +3437,23 @@
         "@emotion/styled": {
           "optional": true
         },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.1.1.tgz",
-      "integrity": "sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@mui/utils": "^7.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.17.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3473,20 +3470,19 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.1.1.tgz",
-      "integrity": "sha512-R2wpzmSN127j26HrCPYVQ53vvMcT5DaKLoWkrfwUYq3cYytL6TQrCH8JBH3z79B6g4nMZZVoaXrxO757AlShaw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1",
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
         "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3507,22 +3503,22 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.1.1.tgz",
-      "integrity": "sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@mui/private-theming": "^7.1.1",
-        "@mui/styled-engine": "^7.1.1",
-        "@mui/types": "^7.4.3",
-        "@mui/utils": "^7.1.1",
-        "clsx": "^2.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.17.1",
+        "@mui/styled-engine": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3547,13 +3543,10 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.3.tgz",
-      "integrity": "sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.1"
-      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3564,20 +3557,20 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.1.1.tgz",
-      "integrity": "sha512-BkOt2q7MBYl7pweY2JWwfrlahhp+uGLR8S+EhiyRaofeRYUWL2YKbSGQvN4hgSN1i8poN0PaUiii1kEMrchvzg==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@mui/types": "^7.4.3",
-        "@types/prop-types": "^15.7.14",
+        "@babel/runtime": "^7.23.9",
+        "@mui/types": "~7.2.15",
+        "@types/prop-types": "^15.7.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.1.0"
+        "react-is": "^19.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4254,9 +4247,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -8490,9 +8483,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/planit/package.json
+++ b/planit/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^7.1.1",
-    "@mui/material": "^7.1.1",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^5.18.0",
+    "@mui/material": "^5.18.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/planit/src/HomePage.tsx
+++ b/planit/src/HomePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+// import React from 'react';
 import { AppBar, Toolbar, Typography, Button, Box, Container } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import logo from './assets/logo.png'; 

--- a/planit/src/Planitpage.tsx
+++ b/planit/src/Planitpage.tsx
@@ -1,6 +1,7 @@
-import type React from "react"
+// import type React from "react"
 import logo from './assets/logo.png'; 
-import { useState, useEffect } from "react"
+// import { useState, useEffect } from "react"
+import { useState } from "react"
 import {
   Box,
   Paper,
@@ -52,7 +53,8 @@ const theme = createTheme({
 })
 
 export default function PlanitPage() {
-  const [activeSection, setActiveSection] = useState<"profile" | "events" | "chat" | "subjects">("chat");
+  // const [activeSection, setActiveSection] = useState<"profile" | "events" | "chat" | "subjects">("chat");
+  const [activeSection, setActiveSection] = useState<"chat" | "subjects">("chat");
 
   return (
     <ThemeProvider theme={theme}>
@@ -97,8 +99,8 @@ export default function PlanitPage() {
             }}
           >
             {activeSection === "chat" && <ChatContainer />}
-            {activeSection === "profile" && <ProfileSection />} 
-            {activeSection === "events" && <CalendarSection />}
+            {/*{activeSection === "profile" && <ProfileSection />} */}
+            {/*{activeSection === "events" && <CalendarSection />}*/}
             {activeSection === "subjects" && <SubjectsSection />}
           </Box>
         </Paper>

--- a/planit/src/main.tsx
+++ b/planit/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route} from 'react-router-dom'
 import './index.css'
-import App from './App.tsx'
+// import App from './App.tsx'
 import HomePage from './HomePage.tsx'
 import Planitpage from './Planitpage.tsx'
 

--- a/planit/src/sidebar/chat/ChatContainer.test.tsx
+++ b/planit/src/sidebar/chat/ChatContainer.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ChatContainer from "./ChatContainer";
 

--- a/planit/src/sidebar/chat/ChatContainer.tsx
+++ b/planit/src/sidebar/chat/ChatContainer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { useState, useEffect, useRef } from "react";
 import ChatSection from "./ChatSection";
 import type { Message } from "./types";
@@ -8,7 +8,8 @@ export default function ChatContainer() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  // const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   // Fetch chat history on mount
   useEffect(() => {
@@ -17,7 +18,8 @@ export default function ChatContainer() {
         setMessages(
           history.map((msg, idx) => ({
             id: String(idx),
-            role: msg.role === "model" ? "assistant" : "user",
+            // role: msg.role === "model" ? "assistant" : "user",
+            role: (msg.role as "model" | "user") === "model" ? "assistant" : "user",
             content: msg.text,
           }))
         )

--- a/planit/src/sidebar/chat/ChatSection.tsx
+++ b/planit/src/sidebar/chat/ChatSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { Box, Paper, Typography, TextField, IconButton } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 
@@ -12,7 +12,8 @@ type ChatSectionProps = {
   messages: Message[];
   input: string;
   isLoading: boolean;
-  messagesEndRef: React.RefObject<HTMLDivElement>;
+  // messagesEndRef: React.RefObject<HTMLDivElement>;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
   handleSubmit: (e: React.FormEvent) => void;
   setInput: React.Dispatch<React.SetStateAction<string>>;
 };

--- a/planit/src/sidebar/subjects/AddSubjectDialog.test.tsx
+++ b/planit/src/sidebar/subjects/AddSubjectDialog.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import AddSubjectDialog from "./AddSubjectDialog";
 

--- a/planit/src/sidebar/subjects/AddSubjectDialog.tsx
+++ b/planit/src/sidebar/subjects/AddSubjectDialog.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+// import React, { useState } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -6,7 +7,7 @@ import {
   DialogActions,
   Button,
   TextField,
-  Box,
+//   Box,
   Typography,
   IconButton,
 } from "@mui/material";

--- a/planit/src/sidebar/subjects/SubjectsSection.test.tsx
+++ b/planit/src/sidebar/subjects/SubjectsSection.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SubjectsSection from "./SubjectsSection";
 import '@testing-library/jest-dom';

--- a/planit/src/sidebar/subjects/SubjectsSection.tsx
+++ b/planit/src/sidebar/subjects/SubjectsSection.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+// import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Paper,
@@ -7,7 +8,8 @@ import {
   IconButton,
 
 } from "@mui/material";
-import { ExpandLess, ExpandMore, Delete, Add, Description } from "@mui/icons-material";
+// import { ExpandLess, ExpandMore, Delete, Add, Description } from "@mui/icons-material";
+import { ExpandLess, ExpandMore, Delete, Add } from "@mui/icons-material";
 import AddSubjectDialog from "./AddSubjectDialog";
 
 // Subject and file types
@@ -86,7 +88,7 @@ async function deleteSubject(id: string) {
 export default function SubjectsSection() {
   const [subjects, setSubjects] = useState<Subject[]>([]);
   const [loading, setLoading] = useState(true);
-  const [newSubject, setNewSubject] = useState("");
+  // const [newSubject, setNewSubject] = useState("");
   const [adding, setAdding] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
 


### PR DESCRIPTION
The frontend build pipeline was failing due to a combination of dependency mismatches, strict TypeScript errors, and unused code. This commit addresses all reported build errors to unblock the CI/CD workflow.

The key changes include:

- **Dependency Downgrade:**
  - Downgraded Material UI (`@mui/material`) and related packages from v7 to v5. The codebase was written using the MUI v5 API, and the upgrade to v7 introduced breaking changes, such as the error with the `Grid` component's `item` prop.

- **TypeScript Type Corrections:**
  - Corrected the type for `useRef` from `useRef<HTMLDivElement>` to `useRef<HTMLDivElement | null>` to match its initial `null` value.
  - Added a type assertion to a string comparison to resolve a type overlap error (`TS2367`).

- **Removed Unused Code:**
  - Removed unused `React` imports, as they are no longer necessary with modern JSX transforms.
  - Cleaned up unused variables, imports, and state hooks (`useEffect`, `useState`) that were causing `TS6133` errors.

- **Disabled Incomplete Features:**
  - Temporarily commented out references to `ProfileSection` and `CalendarSection` to resolve `TS2304` and `TS2552` errors, as these components appear to be missing or incomplete.