### PR TITLE
fix: Align Firebase hosting path with build output

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "frontend/dist",
+    "public": "planit/dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
Updates the `public` directory path in `firebase.json` to match the actual build output location.

The deployment was failing with the error "Directory 'frontend/dist' for Hosting does not exist." This occurred because `firebase.json` specified `frontend/dist` as the public directory, while the build command (`npm --prefix planit run build`) generated the assets in `planit/dist`.

This change corrects the path to `planit/dist`, resolving the error and allowing the deployment to find the correct build artifacts.