### PR TITLE
fix: Implement environment-based API routing

### DIFF
--- a/planit/.env.development
+++ b/planit/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/planit/src/sidebar/chat/api.ts
+++ b/planit/src/sidebar/chat/api.ts
@@ -1,8 +1,10 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
 export async function sendMessageToBackend(message: string): Promise<string> {
   const formData = new FormData();
   formData.append("message", message);
 
-  const response = await fetch("http://localhost:8000/chat/message", {
+  const response = await fetch(`${API_BASE_URL}/chat/message`, {
     method: "POST",
     body: formData,
   });
@@ -12,7 +14,7 @@ export async function sendMessageToBackend(message: string): Promise<string> {
 
 
 export async function fetchChatHistory(): Promise<{ role: "user" | "assistant"; text: string }[]> {
-  const response = await fetch("http://localhost:8000/chat/history");
+  const response = await fetch(`${API_BASE_URL}/chat/history`);
   if (!response.ok) throw new Error("Erro ao buscar histórico do chat");
   return await response.json();
 }

--- a/planit/src/sidebar/subjects/SubjectsSection.tsx
+++ b/planit/src/sidebar/subjects/SubjectsSection.tsx
@@ -12,6 +12,8 @@ import {
 import { ExpandLess, ExpandMore, Delete, Add } from "@mui/icons-material";
 import AddSubjectDialog from "./AddSubjectDialog";
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
 // Subject and file types
 type Subject = {
   id: string;
@@ -61,7 +63,7 @@ const subjectColors: Record<string, string> = {
 
 async function fetchSubjects(): Promise<Subject[]> {
   
-  const res = await fetch("http://localhost:8000/course/list");
+  const res = await fetch(`${API_BASE_URL}/course/list`);
   if (!res.ok) throw new Error("Erro ao buscar matérias");
   return await res.json();
 }
@@ -70,7 +72,7 @@ async function addSubject(title: string, file: File): Promise<any> {
   const formData = new FormData();
   formData.append("message", title); // nome da materia
   formData.append("files", file);   // arquivo
-  const res = await fetch("http://localhost:8000/course/ai", {
+  const res = await fetch(`${API_BASE_URL}/course/ai`, {
     method: "POST",
     body: formData,
   });
@@ -79,7 +81,7 @@ async function addSubject(title: string, file: File): Promise<any> {
 }
 
 async function deleteSubject(id: string) {
-  const res = await fetch(`http://localhost:8000/subjects/${id}`, {
+  const res = await fetch(`${API_BASE_URL}/subjects/${id}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error("Erro ao remover matéria");


### PR DESCRIPTION
Refactors frontend API calls to support both local development and production environments by removing hardcoded URLs. This resolves the critical issue where the deployed production application was failing because it attempted to make API calls to `localhost`.

This change introduces a `VITE_API_URL` environment variable to dynamically configure the API's base URL.

- A new `.env.development` file sets the API URL for the local environment.
- Frontend `fetch` calls are updated to use the `VITE_API_URL` variable, falling back to a relative path for production builds.