### PR TITLE
fix: Standardize API endpoints under /api prefix

### DIFF
--- a/planit/src/sidebar/chat/api.ts
+++ b/planit/src/sidebar/chat/api.ts
@@ -4,7 +4,7 @@ export async function sendMessageToBackend(message: string): Promise<string> {
   const formData = new FormData();
   formData.append("message", message);
 
-  const response = await fetch(`${API_BASE_URL}/chat/message`, {
+  const response = await fetch(`${API_BASE_URL}/api/chat/message`, {
     method: "POST",
     body: formData,
   });
@@ -14,7 +14,7 @@ export async function sendMessageToBackend(message: string): Promise<string> {
 
 
 export async function fetchChatHistory(): Promise<{ role: "user" | "assistant"; text: string }[]> {
-  const response = await fetch(`${API_BASE_URL}/chat/history`);
+  const response = await fetch(`${API_BASE_URL}/api/chat/history`);
   if (!response.ok) throw new Error("Erro ao buscar histórico do chat");
   return await response.json();
 }

--- a/planit/src/sidebar/subjects/SubjectsSection.tsx
+++ b/planit/src/sidebar/subjects/SubjectsSection.tsx
@@ -63,7 +63,7 @@ const subjectColors: Record<string, string> = {
 
 async function fetchSubjects(): Promise<Subject[]> {
   
-  const res = await fetch(`${API_BASE_URL}/course/list`);
+  const res = await fetch(`${API_BASE_URL}/api/course/list`);
   if (!res.ok) throw new Error("Erro ao buscar matérias");
   return await res.json();
 }
@@ -72,7 +72,7 @@ async function addSubject(title: string, file: File): Promise<any> {
   const formData = new FormData();
   formData.append("message", title); // nome da materia
   formData.append("files", file);   // arquivo
-  const res = await fetch(`${API_BASE_URL}/course/ai`, {
+  const res = await fetch(`${API_BASE_URL}/api/course/ai`, {
     method: "POST",
     body: formData,
   });
@@ -81,7 +81,7 @@ async function addSubject(title: string, file: File): Promise<any> {
 }
 
 async function deleteSubject(id: string) {
-  const res = await fetch(`${API_BASE_URL}/subjects/${id}`, {
+  const res = await fetch(`${API_BASE_URL}/api/subjects/${id}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error("Erro ao remover matéria");

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -14,10 +14,10 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
-app.include_router(user_router)
-app.include_router(chat_router)
-app.include_router(course_router)
-app.include_router(events_router)
+app.include_router(user_router, prefix="/api")
+app.include_router(chat_router, prefix="/api")
+app.include_router(course_router, prefix="/api")
+app.include_router(events_router, prefix="/api")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/server/tests/routers/test_chat_router.py
+++ b/server/tests/routers/test_chat_router.py
@@ -62,7 +62,7 @@ def test_get_chat_history(client, mock_chat_crud, mock_user, mock_db_session):
         ChatMessageBase(role=ChatRole.USER, text="Test message").model_dump(mode='json')
     ]
 
-    response = client.get("/chat/history")
+    response = client.get("/api/chat/history")
 
     assert response.status_code == 200
     assert response.json() == expected_response_data
@@ -70,7 +70,7 @@ def test_get_chat_history(client, mock_chat_crud, mock_user, mock_db_session):
 
 
 def test_delete_chat_history(client, mock_chat_crud, mock_user, mock_db_session):
-    response = client.delete("/chat/history")
+    response = client.delete("/api/chat/history")
 
     assert response.status_code == 200
     mock_chat_crud.delete_chat_history.assert_called_once_with(db=mock_db_session, user_uuid=mock_user.uuid)
@@ -90,7 +90,7 @@ async def test_send_chat_message(client, mock_chat_crud, mock_ai_service, mock_u
         ChatMessage(role=ChatRole.USER, text="Old message", content=json.dumps([history_content.model_dump()]))
     ]
 
-    response = client.post("/chat/message", data={"message": user_message_text})
+    response = client.post("/api/chat/message", data={"message": user_message_text})
 
     assert response.status_code == 200
     assert response.json() == ai_response_text

--- a/server/tests/routers/test_course_router.py
+++ b/server/tests/routers/test_course_router.py
@@ -70,7 +70,7 @@ def client(mock_course_crud, mock_chat_crud, mock_ai_service, mock_current_user)
 
 
 def test_list_courses(client, mock_course_crud, mock_current_user):
-    response = client.get("/course/list")
+    response = client.get("/api/course/list")
 
     assert response.status_code == 200
     assert len(response.json()) == 1
@@ -86,7 +86,7 @@ async def test_create_course_success(client, mock_course_crud, mock_chat_crud, m
     files = [("files", ("mock.pdf", BytesIO(file_content), "application/pdf"))]
     form_data = {"message": "Mock message.", "timezone": "America/Sao_Paulo"}
 
-    response = client.post("/course/ai", files=files, data=form_data)
+    response = client.post("/api/course/ai", files=files, data=form_data)
 
     assert response.json()["title"] == "New Course"
 
@@ -120,7 +120,7 @@ async def test_create_course_invalid_timezone(client):
     files = [("files", ("mock.pdf", BytesIO(file_content), "application/pdf"))]
     form_data = {"timezone": "Invalid/Timezone"}
 
-    response = client.post("/course/ai", files=files, data=form_data)
+    response = client.post("/api/course/ai", files=files, data=form_data)
 
     assert response.status_code == 400
     assert "Invalid timezone identifier" in response.json()["detail"]
@@ -131,7 +131,7 @@ async def test_create_course_unsupported_media_type(client):
     file_content = b"zip content"
     files = [("files", ("mock.zip", BytesIO(file_content), "application/zip"))]
 
-    response = client.post("/course/ai", files=files)
+    response = client.post("/api/course/ai", files=files)
 
     assert response.status_code == 415
     assert "Unsupported Media Type" in response.json()["detail"]
@@ -142,7 +142,7 @@ async def test_create_course_entity_too_large(client):
     large_content = b"0" * (20 * 1024 * 1024)
     files = [("files", ("large_file.pdf", BytesIO(large_content), "application/pdf"))]
 
-    response = client.post("/course/ai", files=files)
+    response = client.post("/api/course/ai", files=files)
 
     assert response.status_code == 413
     assert "Request Entity Too Large" in response.json()["detail"]
@@ -154,7 +154,7 @@ async def test_create_course_ai_api_error(client, mock_ai_service):
     file_content = b"pdf content"
     files = [("files", ("mock.pdf", BytesIO(file_content), "application/pdf"))]
 
-    response = client.post("/course/ai", files=files)
+    response = client.post("/api/course/ai", files=files)
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Error while parsing course information"
@@ -168,7 +168,7 @@ async def test_create_course_pydantic_validation_error(client, mock_ai_service):
     file_content = b"pdf content"
     files = [("files", ("mock.pdf", BytesIO(file_content), "application/pdf"))]
 
-    response = client.post("/course/ai", files=files)
+    response = client.post("/api/course/ai", files=files)
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Error while parsing course information"


### PR DESCRIPTION
This commit aligns the frontend and backend API paths by introducing a global `/api` prefix to all routes.

This change ensures that requests from the deployed frontend are correctly proxied to the backend via Firebase Hosting rewrites, fixing the issue where API calls were failing in production.