### PR TITLE
chore: Split CI workflows and update backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'backend/**'
+      - 'server/**'
       - '.github/workflows/deploy-backend.yml'
 
   workflow_dispatch:
@@ -60,7 +60,7 @@ jobs:
           image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
           flags: |
             --ingress=all
-            --no-allow-unauthenticated
+            --allow-unauthenticated
             --service-account=${{ env.SERVICE_ACCOUNT }}
             --add-cloudsql-instances=${{ env.DB_CONNECTION_NAME }}
             --memory=512Mi

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration Tests
+name: Backend CI Tests
 
 permissions:
   contents: read
@@ -8,15 +8,18 @@ on:
     branches:
       - main
       - developer
+    paths:
+      - 'server/**'
   pull_request:
     branches:
       - main
       - developer
+    paths:
+      - 'server/**'
 
 jobs:
   backend-ci:
     name: Backend CI Tests
-    if: "github.event_name == 'pull_request' || github.event_name == 'push'"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -38,25 +41,3 @@ jobs:
 
       - name: Run tests
         run: pytest
-
-  frontend-ci:
-    name: Frontend CI Tests
-    if: "github.event_name == 'pull_request' || github.event_name == 'push'"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./planit
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npm test

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,0 +1,40 @@
+name: Frontend CI Tests
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - developer
+    paths:
+      - 'planit/**'
+  pull_request:
+    branches:
+      - main
+      - developer
+    paths:
+      - 'planit/**'
+
+jobs:
+  frontend-ci:
+    name: Frontend CI Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./planit
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This commit introduces several improvements to the CI/CD pipeline configuration for better efficiency and to correct deployment settings.

Split the monolithic `cicd.yml` into two separate workflows (`test-backend.yml` and `test-frontend.yml`). This change ensures CI jobs are only triggered when relevant code is modified, reducing unnecessary pipeline runs and providing faster feedback.

- The backend CI workflow now runs only on changes within the `/server` directory.
- The frontend CI workflow runs only on changes within the `/planit` directory.

Additionally, the `deploy-backend` workflow has been updated:
- Corrected the `on.push.paths` filter to ensure it triggers correctly.
- Switched to the `--allow-unauthenticated` flag during Cloud Run deployment. This is necessary to allow the web app hosted on Firebase to connect to the backend service.