### PR TITLE
feat: Implement lecture management endpoints

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.db import Base, engine
 from app.routers import chat_router, course_router, user_router, events_router
+from routers import lecture_router
 
 Base.metadata.create_all(bind=engine)
 
@@ -17,6 +18,7 @@ app = FastAPI(lifespan=lifespan)
 app.include_router(user_router, prefix="/api")
 app.include_router(chat_router, prefix="/api")
 app.include_router(course_router, prefix="/api")
+app.include_router(lecture_router, prefix="/api")
 app.include_router(events_router, prefix="/api")
 app.add_middleware(
     CORSMiddleware,

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -2,3 +2,4 @@ from .chat_router import chat_router
 from .course_router import course_router
 from .user_router import user_router
 from .events_router import events_router
+from .lecture_router import lecture_router

--- a/server/app/routers/lecture_router.py
+++ b/server/app/routers/lecture_router.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from datetime import datetime
 
-from app.crud import get_lecture_crud
+from fastapi import APIRouter, Depends, HTTPException, Form, Query
+from sqlalchemy.orm import Session
+from starlette import status
+
+from app.core.security import get_current_user
+from app.crud import get_lecture_crud, get_course_crud, CRUDLecture, CRUDCourse
 from app.dependencies import get_db
+from app.models import User as UserModel, Course as CourseModel, Lecture as LectureModel
 from app.schemas import Lecture, LectureCreate, LectureUpdate
 
 lecture_router = APIRouter(
@@ -11,30 +16,120 @@ lecture_router = APIRouter(
 )
 
 
-@lecture_router.get("/{uuid}", response_model=Lecture)
-def get_lecture(uuid: str, db: Session = Depends(get_db), crud=Depends(get_lecture_crud)):
-    lecture = crud.get(db, obj_uuid=uuid)
-    if not lecture:
-        raise HTTPException(status_code=404, detail="Lecture not found")
+@lecture_router.get("/", response_model=Lecture)
+def get_lecture(
+        lecture_uuid: str = Query(),
+        db: Session = Depends(get_db),
+        course_crud: CRUDCourse = Depends(get_course_crud),
+        lecture_crud: CRUDLecture = Depends(get_lecture_crud),
+        user: UserModel = Depends(get_current_user),
+):
+    db_lecture = _validate_authorization_lecture(
+        lecture_uuid=lecture_uuid,
+        db=db,
+        user=user,
+        course_crud=course_crud,
+        lecture_crud=lecture_crud,
+    )
+    lecture: Lecture = Lecture.model_validate(db_lecture)
     return lecture
 
 
-@lecture_router.put("/{uuid}", response_model=Lecture)
-def update_lecture(uuid: str, lecture_in: LectureUpdate, db: Session = Depends(get_db), crud=Depends(get_lecture_crud)):
-    lecture = crud.get(db, obj_uuid=uuid)
-    if not lecture:
-        raise HTTPException(status_code=404, detail="Lecture not found")
-    return crud.update(db, db_obj=lecture, obj_in=lecture_in)
+@lecture_router.put("/", response_model=Lecture)
+def update_lecture(
+        lecture_uuid: str = Form(),
+        new_title: str | None = Form(None),
+        new_start_datetime: datetime | None = Form(None),
+        new_end_datetime: datetime | None = Form(None),
+        new_summary: str | None = Form(None),
+        new_present: bool | None = Form(None),
+        db: Session = Depends(get_db),
+        course_crud: CRUDCourse = Depends(get_course_crud),
+        lecture_crud: CRUDLecture = Depends(get_lecture_crud),
+        user: UserModel = Depends(get_current_user),
+):
+    db_lecture = _validate_authorization_lecture(
+        lecture_uuid=lecture_uuid,
+        db=db,
+        user=user,
+        course_crud=course_crud,
+        lecture_crud=lecture_crud,
+    )
+    lecture_update: LectureUpdate = LectureUpdate(
+        title=new_title,
+        start_datetime=new_start_datetime,
+        end_datetime=new_end_datetime,
+        summary=new_summary,
+        present=new_present,
+    )
+    updated_db_lecture: LectureModel = lecture_crud.update(db=db, db_obj=db_lecture, obj_in=lecture_update)
+    updated_lecture: Lecture = Lecture.model_validate(updated_db_lecture)
+    return updated_lecture
 
 
 @lecture_router.post("/", response_model=Lecture)
-def create_lecture(lecture_in: LectureCreate, db: Session = Depends(get_db), crud=Depends(get_lecture_crud)):
-    return crud.create(db, obj_in=lecture_in)
+def create_lecture(
+        title: str = Form(),
+        start_datetime: datetime = Form(),
+        end_datetime: datetime = Form(),
+        summary: str | None = Form(None),
+        course_uuid: str = Form(),
+        db: Session = Depends(get_db),
+        course_crud: CRUDCourse = Depends(get_course_crud),
+        lecture_crud: CRUDLecture = Depends(get_lecture_crud),
+        user: UserModel = Depends(get_current_user),
+):
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    db_course: CourseModel = course_crud.get(db=db, obj_uuid=course_uuid)
+    if not db_course or db_course.owner_uuid != user.uuid:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    lecture: LectureCreate = LectureCreate(
+        title=title,
+        start_datetime=start_datetime,
+        end_datetime=end_datetime,
+        summary=summary,
+        course_uuid=course_uuid,
+    )
+    db_lecture: LectureModel = lecture_crud.create(db=db, obj_in=lecture)
+    created_lecture: Lecture = Lecture.model_validate(db_lecture)
+    return created_lecture
 
 
-@lecture_router.delete("/{uuid}", response_model=Lecture)
-def delete_lecture(uuid: str, db: Session = Depends(get_db), crud=Depends(get_lecture_crud)):
-    lecture = crud.get(db, obj_uuid=uuid)
-    if not lecture:
-        raise HTTPException(status_code=404, detail="Lecture not found")
-    return crud.remove(db, obj_uuid=uuid)
+@lecture_router.delete("/", response_model=Lecture)
+def delete_lecture(
+        lecture_uuid: str = Form(),
+        db: Session = Depends(get_db),
+        course_crud: CRUDCourse = Depends(get_course_crud),
+        lecture_crud: CRUDLecture = Depends(get_lecture_crud),
+        user: UserModel = Depends(get_current_user),
+):
+    db_lecture = _validate_authorization_lecture(
+        lecture_uuid=lecture_uuid,
+        db=db,
+        user=user,
+        course_crud=course_crud,
+        lecture_crud=lecture_crud,
+    )
+    db_lecture = lecture_crud.remove(db=db, obj_uuid=db_lecture.uuid)
+    deleted_lecture: Lecture = Lecture.model_validate(db_lecture)
+    return deleted_lecture
+
+
+def _validate_authorization_lecture(
+        lecture_uuid: str,
+        db: Session,
+        user: UserModel,
+        course_crud: CRUDCourse,
+        lecture_crud: CRUDLecture,
+) -> LectureModel:
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    db_lecture: LectureModel = lecture_crud.get(db=db, obj_uuid=lecture_uuid)
+    if not db_lecture:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    db_course: CourseModel = course_crud.get(db=db, obj_uuid=db_lecture.course_uuid)
+    if not db_course or db_course.owner_uuid != user.uuid:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return db_lecture


### PR DESCRIPTION
This pull request introduces new API endpoints for managing lectures within a course. It adds a complete CRUD (Create, Read, Update, Delete) functionality for lectures, along with the necessary routing and authorization logic.

**Key Changes:**

* **New Lecture Router (`lecture_router.py`)** : A new file has been created to handle all lecture-related API endpoints. This includes endpoints for:
    * `POST /lecture/`: Creates a new lecture for a specified course.
    * `GET /lecture/`: Retrieves the details of a specific lecture.
    * `PUT /lecture/`: Updates the details of an existing lecture, such as title, start/end times, and summary.
    * `DELETE /lecture/`: Deletes a specified lecture.

* **Application Integration** : The new `lecture_router` has been imported and included in the main FastAPI application, making the new endpoints accessible under the `/api` prefix.

* **Authorization and Validation**:
    * Added a `_validate_authorization_lecture` helper function to ensure that only the owner of the course can access or modify its lectures.
    * This function verifies the user's authentication and ownership of the associated course before performing any operation on a lecture. 