### PR TITLE
feat: Implement file uploading and LLM context management

### DIFF
--- a/planit/src/sidebar/chat/ChatSection.tsx
+++ b/planit/src/sidebar/chat/ChatSection.tsx
@@ -1,20 +1,20 @@
-import {Box, Paper, Typography, TextField, IconButton} from "@mui/material";
+import {Alert, Box, Chip, Collapse, IconButton, Paper, TextField, Typography} from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
-import ReactMarkdown from "react-markdown";
+import AttachmentIcon from "@mui/icons-material/Attachment";
+import CloseIcon from '@mui/icons-material/Close';
+import DoNotDisturbOnIcon from '@mui/icons-material/DoNotDisturbOn';
 import type {Components, ExtraProps} from "react-markdown";
+import ReactMarkdown from "react-markdown";
 import type {ReactNode} from "react";
+import React, {useEffect, useRef} from "react";
+import type {Message} from "./types";
+
 
 interface CustomCodeProps extends ExtraProps {
   inline?: boolean;
   className?: string;
   children?: ReactNode;
 }
-
-type Message = {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-};
 
 type ChatSectionProps = {
   messages: Message[];
@@ -23,6 +23,13 @@ type ChatSectionProps = {
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
   handleSubmit: (e: React.FormEvent) => void;
   setInput: React.Dispatch<React.SetStateAction<string>>;
+  filesToSend: File[];
+  handleAttachmentClick: () => void;
+  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleRemoveFile: (file: File) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  fileError: string | null;
+  setFileError: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
 export default function ChatSection({
@@ -32,7 +39,40 @@ export default function ChatSection({
                                       messagesEndRef,
                                       handleSubmit,
                                       setInput,
+                                      filesToSend,
+                                      handleAttachmentClick,
+                                      handleFileChange,
+                                      handleRemoveFile,
+                                      fileInputRef,
+                                      fileError,
+                                      setFileError,
                                     }: ChatSectionProps) {
+  const fileListBoxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fileListBox = fileListBoxRef.current;
+    if (fileListBox) {
+      const handleWheel = (e: WheelEvent) => {
+        if (fileListBox.scrollWidth > fileListBox.clientWidth) {
+          e.preventDefault();
+          fileListBox.scrollLeft += e.deltaY;
+        }
+      };
+      fileListBox.addEventListener('wheel', handleWheel, {passive: false});
+
+      return () => {
+        fileListBox.removeEventListener('wheel', handleWheel);
+      };
+    }
+  }, [filesToSend]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e as unknown as React.FormEvent);
+    }
+  };
+
   const markdownComponents: Components = {
     p: ({node, ...props}) => <Typography variant="body2" paragraph {...props} />,
     ul: ({node, ...props}) => <Typography component="ul" variant="body2" sx={{mt: 0, pl: "20px"}} {...props} />,
@@ -132,7 +172,6 @@ export default function ChatSection({
 
   return (
     <>
-      {/* Mensagens do chat */}
       <Box
         className="custom-scrollbar"
         sx={{
@@ -146,24 +185,36 @@ export default function ChatSection({
         }}
       >
         {messages.map((message) => (
-          <Paper
-            key={message.id}
-            elevation={0}
-            sx={{
-              p: 2,
-              maxWidth: "80%",
-              wordBreak: "break-word",
-              ...(message.role === "user" ? userPaperSx : assistantPaperSx),
-            }}
-          >
-            {message.role === "assistant" ? (
-              <ReactMarkdown components={markdownComponents}>{message.content}</ReactMarkdown>
-            ) : (
-              <Typography variant="body2" sx={{whiteSpace: "pre-wrap"}}>
-                {message.content}
-              </Typography>
+          <Box key={message.id} sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: message.role === 'user' ? 'flex-end' : 'flex-start'
+          }}>
+            {message.files && message.files.length > 0 && (
+              <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 0.5, maxWidth: '80%'}}>
+                {message.files.map((file, index) => (
+                  <Chip key={index} label={file.filename} size="small"/>
+                ))}
+              </Box>
             )}
-          </Paper>
+            <Paper
+              elevation={0}
+              sx={{
+                p: 2,
+                maxWidth: "95%",
+                wordBreak: "break-word",
+                ...(message.role === "user" ? userPaperSx : assistantPaperSx),
+              }}
+            >
+              {message.role === "assistant" ? (
+                <ReactMarkdown components={markdownComponents}>{message.content}</ReactMarkdown>
+              ) : (
+                <Typography variant="body2" sx={{whiteSpace: "pre-wrap"}}>
+                  {message.content}
+                </Typography>
+              )}
+            </Paper>
+          </Box>
         ))}
         {isLoading && (
           <Paper
@@ -182,17 +233,80 @@ export default function ChatSection({
         )}
         <div ref={messagesEndRef}/>
       </Box>
-      {/* Input do chat */}
-      <Box sx={{p: 2}}>
-        <form onSubmit={handleSubmit} style={{display: "flex", gap: 8}}>
+
+      <Box sx={{p: 2, borderTop: '1px solid #e0e0e0'}}>
+        <Collapse in={!!fileError}>
+          <Alert
+            severity="info"
+            icon={<DoNotDisturbOnIcon sx={{color: 'error.main'}}/>}
+            sx={{
+              mb: 1,
+              bgcolor: 'transparent',
+              color: 'text.secondary',
+              borderColor: 'error.main',
+              borderWidth: '2px',
+              borderStyle: 'solid',
+              alignItems: 'center',
+            }}
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setFileError(null);
+                }}
+              >
+                <CloseIcon fontSize="inherit"/>
+              </IconButton>
+            }
+          >
+            {fileError}
+          </Alert>
+        </Collapse>
+
+        {filesToSend.length > 0 && (
+          <Box ref={fileListBoxRef} sx={{mb: 1, display: 'flex', gap: 1, overflowX: 'auto', pb: 1}}
+               className="custom-scrollbar">
+            {filesToSend.map((file, index) => (
+              <Chip
+                key={index}
+                label={file.name}
+                onDelete={() => handleRemoveFile(file)}
+              />
+            ))}
+          </Box>
+        )}
+
+        <form onSubmit={handleSubmit} style={{display: "flex", gap: 8, alignItems: 'flex-end'}}>
+          <input
+            type="file"
+            multiple
+            hidden
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            accept="application/pdf,application/javascript,text/javascript,application/x-python-code,text/x-python,text/plain,text/html,text/css,text/markdown,text/csv,text/xml,application/rtf,image/png,image/jpeg,image/webp,image/heic,image/heif"
+          />
+          <IconButton
+            type="button"
+            onClick={handleAttachmentClick}
+            disabled={isLoading}
+            sx={{flexShrink: 0}}
+          >
+            <AttachmentIcon/>
+          </IconButton>
           <TextField
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Digite sua mensagem..."
+            placeholder="Digite aqui..."
             fullWidth
             variant="outlined"
             size="small"
             disabled={isLoading}
+            multiline
+            minRows={1}
+            maxRows={3}
+            onKeyDown={handleKeyDown}
             sx={{
               "& .MuiOutlinedInput-root": {
                 bgcolor: "#d3d3d3",
@@ -205,8 +319,8 @@ export default function ChatSection({
           <IconButton
             type="submit"
             color="primary"
-            disabled={isLoading}
-            sx={{bgcolor: "#1976d2", color: "white", "&:hover": {bgcolor: "#1565c0"}}}
+            disabled={isLoading || !input.trim()}
+            sx={{bgcolor: "#1976d2", color: "white", "&:hover": {bgcolor: "#1565c0"}, flexShrink: 0}}
           >
             <SendIcon/>
           </IconButton>

--- a/planit/src/sidebar/chat/api.ts
+++ b/planit/src/sidebar/chat/api.ts
@@ -1,8 +1,14 @@
+import type {ChatFile} from "./types";
+
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
 
-export async function sendMessageToBackend(message: string): Promise<string> {
+export async function sendMessageToBackend(message: string, files: File[]): Promise<string> {
   const formData = new FormData();
   formData.append("message", message);
+
+  files.forEach(file => {
+    formData.append("files", file);
+  });
 
   const response = await fetch(`${API_BASE_URL}/api/chat/message`, {
     method: "POST",
@@ -12,8 +18,11 @@ export async function sendMessageToBackend(message: string): Promise<string> {
   return await response.json();
 }
 
-
-export async function fetchChatHistory(): Promise<{ role: "user" | "assistant"; text: string }[]> {
+export async function fetchChatHistory(): Promise<{
+  role: "user" | "assistant";
+  text: string;
+  files: ChatFile[] | null
+}[]> {
   const response = await fetch(`${API_BASE_URL}/api/chat/history`);
   if (!response.ok) throw new Error("Erro ao buscar histórico do chat");
   return await response.json();

--- a/planit/src/sidebar/chat/types.ts
+++ b/planit/src/sidebar/chat/types.ts
@@ -1,5 +1,11 @@
+export type ChatFile = {
+  filename: string;
+  mimetype: string;
+};
+
 export type Message = {
   id: string;
   role: "user" | "assistant";
   content: string;
+  files?: ChatFile[];
 };

--- a/server/app/crud/chat_crud.py
+++ b/server/app/crud/chat_crud.py
@@ -1,11 +1,12 @@
+import json
 import uuid
 from typing import Type, TypeVar
 
 from sqlalchemy.orm import Session
 
+from app.core.db import Base
 from app.models import ChatMessage, User
 from app.schemas import ChatMessage as ChatMessageSchema
-from app.core.db import Base
 
 ModelType = TypeVar("ModelType", bound=Base)
 
@@ -26,8 +27,13 @@ class CRUDChat:
     def append_chat_history(self, db: Session, user_uuid: str, obj_in: ChatMessageSchema) -> None:
         user = db.get(User, user_uuid)
         next_order = len(user.chat_history)
+
+        obj_in_data = obj_in.model_dump(mode='json')
+        if 'files' in obj_in_data and obj_in_data['files'] is not None:
+            obj_in_data['files'] = json.dumps(obj_in_data['files'])
+
         db_msg = self.model(
-            **obj_in.model_dump(mode='json'),
+            **obj_in_data,
             uuid=str(uuid.uuid4()),
             order=next_order,
             owner_uuid=user.uuid
@@ -36,7 +42,7 @@ class CRUDChat:
         db.commit()
 
     def delete_chat_history(self, db: Session, user_uuid: str) -> int:
-        num_deleted = db.query(self.model).filter(self.model.owner_uuid.is_(user_uuid)).delete()
+        num_deleted = db.query(self.model).filter_by(owner_uuid=user_uuid).delete()
         db.commit()
         return num_deleted
 

--- a/server/app/models/chat_message_model.py
+++ b/server/app/models/chat_message_model.py
@@ -13,6 +13,7 @@ class ChatMessage(Base):
     order = Column(Integer, nullable=False)
     role = Column(String, nullable=False)
     text = Column(Text, nullable=False)
+    files = Column(Text, nullable=True)
     content = Column(Text, nullable=False)
 
     owner_uuid = Column(String, ForeignKey("users.uuid"), index=True, nullable=False)

--- a/server/app/routers/chat_router.py
+++ b/server/app/routers/chat_router.py
@@ -1,6 +1,6 @@
 import json
 
-from fastapi import APIRouter, HTTPException, Depends, Form
+from fastapi import APIRouter, HTTPException, Depends, Form, UploadFile
 from google.genai.types import Content
 from sqlalchemy.orm import Session
 from starlette import status
@@ -10,7 +10,7 @@ from app.core.security import get_current_user
 from app.crud import get_chat_crud
 from app.dependencies import get_db
 from app.models import User
-from app.schemas import ChatMessage, ChatMessageBase, ChatRole
+from app.schemas import ChatMessage, ChatMessageBase, ChatRole, ChatFile
 from app.services import get_google_ai_service
 
 chat_router = APIRouter(
@@ -44,6 +44,7 @@ async def delete_chat_history(
 @chat_router.post("/message", response_model=str)
 async def send_chat_message(
         message: str = Form(),
+        files: list[UploadFile] | None = None,
         chat_crud=Depends(get_chat_crud),
         ai_service=Depends(get_google_ai_service),
         db: Session = Depends(get_db),
@@ -51,6 +52,27 @@ async def send_chat_message(
 ):
     if not user:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Not authorized")
+
+    chat_files = []
+    if files:
+        if len(files) > 10:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Cannot upload more than 10 files.",
+            )
+        total_size = sum(file.size for file in files)
+        if total_size > 19922944:  # 19MB
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Total file size exceeds the 19MB limit.",
+            )
+        for file in files:
+            if file.content_type not in settings.SUPPORTED_FILE_TYPES:
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail=f"File type not supported: {file.content_type}",
+                )
+            chat_files.append(ChatFile(filename=file.filename, mimetype=file.content_type))
 
     history = chat_crud.get_chat_history(db=db, user_uuid=user.uuid)
     llm_context: list[Content] = [
@@ -61,10 +83,20 @@ async def send_chat_message(
     response, new_content = await ai_service.send_message(
         instruction=settings.CHAT_SYSTEM_INSTRUCTIONS,
         message=message,
+        files=[(await file.read(), file.content_type) for file in files] if files else None,
         llm_context=llm_context)
 
-    user_message = ChatMessage(role=ChatRole.USER, text=message, content=json.dumps([new_content[0].model_dump()]))
-    model_message = ChatMessage(role=ChatRole.MODEL, text=response, content=json.dumps([new_content[1].model_dump()]))
+    user_message = ChatMessage(
+        role=ChatRole.USER,
+        text=message,
+        files=chat_files if len(chat_files) else None,
+        content=json.dumps([new_content[0].model_dump(mode='json')]),
+    )
+    model_message = ChatMessage(
+        role=ChatRole.MODEL,
+        text=response,
+        content=json.dumps([new_content[1].model_dump(mode='json')]),
+    )
 
     chat_crud.append_chat_history(db=db, user_uuid=user.uuid, obj_in=user_message)
     chat_crud.append_chat_history(db=db, user_uuid=user.uuid, obj_in=model_message)

--- a/server/app/schemas/__init__.py
+++ b/server/app/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .chat_schemas import ChatRole, ChatMessage, ChatMessageBase
+from .chat_schemas import ChatRole, ChatMessage, ChatMessageBase, ChatFile
 from .course_schema import Course, CourseBase, CourseCreate, CourseUpdate, CourseGenerate, CourseSummary, \
     CourseDeleteResponse
 from .evaluation_schema import EvaluationTypes, Evaluation, EvaluationBase, EvaluationCreate, EvaluationUpdate, \

--- a/server/app/schemas/chat_schemas.py
+++ b/server/app/schemas/chat_schemas.py
@@ -1,6 +1,7 @@
+import json
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class ChatRole(Enum):
@@ -8,9 +9,26 @@ class ChatRole(Enum):
     MODEL = "model"
 
 
+class ChatFile(BaseModel):
+    filename: str
+    mimetype: str
+
+
 class ChatMessageBase(BaseModel):
     role: ChatRole
     text: str
+    files: list[ChatFile] | None = None
+
+    @field_validator('files', mode='before')
+    @classmethod
+    def parse_files_json(cls, v):
+        """
+        When loading from the DB, 'files' is a JSON string.
+        This validator parses it into a Python list before other validation.
+        """
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
 
 
 class ChatMessage(ChatMessageBase):


### PR DESCRIPTION
This commit introduces the capability for users to upload files within the chat interface. It also adds backend handling for attachments and a LLM context management feature to ensure API stability.

Key changes:

- **File Upload Functionality:**
    - Users can now attach up to 10 files (including PDFs, text files, code, and images) to a chat message via a new attachment button.
    - The UI displays staged files as removable chips and provides clear error feedback for unsupported types or exceeding file limits.
    - Messages in the chat history now display the files that were sent with them.

- **Backend Integration:**
    - The chat API endpoint (`/api/chat/message`) now handles `multipart/form-data` to process text and multiple files.
    - Added backend validation for file count, total upload size, and supported MIME types.
    - `GoogleAIService` is updated to send file data to the Gemini model.
    - The `ChatMessage` database model now includes a `files` field to store attachment metadata.

- **Context Window Management:**
    - Implemented an automatic history trimming mechanism in `GoogleAIService`. This prevents API errors by removing the oldest messages from the context if it exceeds a defined size limit.

- **Bug Fix:**
    - Fixed a bug in `CRUDChat.delete_chat_history` where the SQLAlchemy query used an incorrect operator (`.is_`) to filter by `owner_uuid`, which has been corrected to `filter_by()` to ensure chat history is cleared properly.

- **UX Enhancements:**
    - The chat input field is now multiline, allowing for easier composition of long messages.
    - Pressing Enter (without Shift) now sends the message for a faster user experience.